### PR TITLE
HTB-325 HMRC 401 UNAUTHORIZED is retried without fetching a new token

### DIFF
--- a/src/SFA.DAS.EmploymentCheck.Functions.UnitTests/Application/Services/HmrcServiceTests/WhenCheckingEmploymentStatus.cs
+++ b/src/SFA.DAS.EmploymentCheck.Functions.UnitTests/Application/Services/HmrcServiceTests/WhenCheckingEmploymentStatus.cs
@@ -627,6 +627,33 @@ namespace SFA.DAS.EmploymentCheck.Functions.UnitTests.Application.Services.HmrcS
         }
 
         [Test]
+        public async Task Then_a_new_token_is_retrieved_for_each_retry_of_any_ApiException()
+        {
+            // Arrange
+            var exception = new ApiHttpException(
+                (int)HttpStatusCode.NoContent,
+                _fixture.Create<string>(),
+                _fixture.Create<string>(),
+                _fixture.Create<string>(),
+                _fixture.Create<Exception>()
+            );
+
+            _apprenticeshipLevyServiceMock.Setup(x => x.GetEmploymentStatus(
+                    _token.AccessCode,
+                    _request.PayeScheme,
+                    _request.Nino,
+                    _request.MinDate,
+                    _request.MaxDate))
+                .ThrowsAsync(exception);
+
+            // Act
+            await _sut.IsNationalInsuranceNumberRelatedToPayeScheme(_request);
+
+            // Assert
+            _tokenServiceMock.Verify(x => x.GetPrivilegedAccessTokenAsync(), Times.Exactly(_settings.TransientErrorRetryCount + 1));
+        }
+
+        [Test]
         public async Task Then_retry_delay_time_is_increased_When_TooManyRequests()
         {
             // Arrange

--- a/src/SFA.DAS.EmploymentCheck.Functions.UnitTests/Application/Services/HmrcServiceTests/WhenCheckingEmploymentStatus.cs
+++ b/src/SFA.DAS.EmploymentCheck.Functions.UnitTests/Application/Services/HmrcServiceTests/WhenCheckingEmploymentStatus.cs
@@ -55,7 +55,8 @@ namespace SFA.DAS.EmploymentCheck.Functions.UnitTests.Application.Services.HmrcS
                 MinimumUpdatePeriodInDays = 0,
                 TooManyRequestsRetryCount = 10,
                 TransientErrorRetryCount = 2,
-                TransientErrorDelayInMs = 1
+                TransientErrorDelayInMs = 1,
+                TokenFailureRetryDelayInMs = 0
             };
 
             _rateLimiterRepositoryMock.Setup(r => r.GetHmrcRateLimiterOptions()).ReturnsAsync(_settings);

--- a/src/SFA.DAS.EmploymentCheck.Functions/Application/Services/Hmrc/HmrcApiRetryPolicies.cs
+++ b/src/SFA.DAS.EmploymentCheck.Functions/Application/Services/Hmrc/HmrcApiRetryPolicies.cs
@@ -91,11 +91,12 @@ namespace SFA.DAS.EmploymentCheck.Functions.Application.Services.Hmrc
 
             return await Task.FromResult<AsyncPolicy>(Policy
                 .Handle<Exception>()
-                .RetryAsync(
+                .WaitAndRetryAsync(
                     retryCount: _settings.TokenRetrievalRetryCount,
-                    onRetryAsync: (exception, retryNumber, context) =>
+                    sleepDurationProvider: _ => TimeSpan.FromMilliseconds(_settings.TokenFailureRetryDelayInMs),
+                    onRetryAsync: (exception, ts, retryNumber, context) =>
                     {
-                        _logger.LogInformation($"{nameof(HmrcApiRetryPolicies)}: Exception error occurred while retrieving token. Retrying ({retryNumber}/{_settings.TokenRetrievalRetryCount})...");
+                        _logger.LogInformation($"{nameof(HmrcApiRetryPolicies)}: Exception occurred while retrieving token. Retrying ({retryNumber}/{_settings.TokenRetrievalRetryCount})... {exception}");
                         return Task.CompletedTask;
                     }
                 ));

--- a/src/SFA.DAS.EmploymentCheck.Functions/Application/Services/Hmrc/HmrcApiRetryPolicies.cs
+++ b/src/SFA.DAS.EmploymentCheck.Functions/Application/Services/Hmrc/HmrcApiRetryPolicies.cs
@@ -50,7 +50,7 @@ namespace SFA.DAS.EmploymentCheck.Functions.Application.Services.Hmrc
                     retryCount: _settings.TransientErrorRetryCount,
                     onRetryAsync: async (exception, retryNumber, context) =>
                     {
-                        _logger.LogInformation($"{nameof(HmrcApiRetryPolicies)}: [{retryNumber}/{_settings.TooManyRequestsRetryCount}] UnauthorizedAccessException occurred. Refreshing access token and retrying...");
+                        _logger.LogInformation($"{nameof(HmrcApiRetryPolicies)}: [{retryNumber}/{_settings.TooManyRequestsRetryCount}] UnauthorizedAccessException occurred. Retrying...");
 
                         await onRetry();
                     }
@@ -66,10 +66,10 @@ namespace SFA.DAS.EmploymentCheck.Functions.Application.Services.Hmrc
                 .WaitAndRetryAsync(
                     retryCount: _settings.TransientErrorRetryCount,
                     sleepDurationProvider: _ => TimeSpan.FromMilliseconds(_settings.TransientErrorDelayInMs),
-                    onRetryAsync: async (exception, retryNumber, context) =>
+                    onRetryAsync: async (exception, ts, retryNumber, context) =>
                     {
                         _logger.LogInformation(
-                            $"{nameof(HmrcApiRetryPolicies)}: ApiHttpException occurred. $[{exception}] Refreshing access token ({retryNumber}/{_settings.TransientErrorRetryCount})...");
+                            $"{nameof(HmrcApiRetryPolicies)}: [{retryNumber}/{_settings.TransientErrorRetryCount}] ApiHttpException occurred. $[{exception}]. Retrying...");
 
                         await onRetry();
                     }

--- a/src/SFA.DAS.EmploymentCheck.Functions/Application/Services/Hmrc/HmrcService.cs
+++ b/src/SFA.DAS.EmploymentCheck.Functions/Application/Services/Hmrc/HmrcService.cs
@@ -87,7 +87,6 @@ namespace SFA.DAS.EmploymentCheck.Functions.Application.Services.Hmrc
             return request;
         }
 
-
         private bool AccessTokenHasExpired()
         {
             var expired = _cachedToken.ExpiryTime < DateTime.Now;
@@ -123,6 +122,7 @@ namespace SFA.DAS.EmploymentCheck.Functions.Application.Services.Hmrc
                 var policy =  await _retryPolicies.GetTokenRetrievalRetryPolicy();
                 await policy.ExecuteAsync(async () =>
                 {
+                    _logger.LogInformation($"{nameof(HmrcService)}: Refreshing access token...");
                     _cachedToken = await _tokenService.GetPrivilegedAccessTokenAsync();
                 });
             }

--- a/src/SFA.DAS.EmploymentCheck.Functions/Application/Services/Hmrc/HmrcService.cs
+++ b/src/SFA.DAS.EmploymentCheck.Functions/Application/Services/Hmrc/HmrcService.cs
@@ -89,7 +89,7 @@ namespace SFA.DAS.EmploymentCheck.Functions.Application.Services.Hmrc
 
         private bool AccessTokenHasExpired()
         {
-            var expired = _cachedToken.ExpiryTime < DateTime.Now;
+            var expired = _cachedToken.ExpiryTime < DateTime.UtcNow;
             if (expired) _logger.LogInformation($"[{nameof(HmrcService)}] Access Token has expired, retrieving a new token.");
             return expired;
         }

--- a/src/SFA.DAS.EmploymentCheck.Functions/Configuration/HmrcApiRateLimiterOptions.cs
+++ b/src/SFA.DAS.EmploymentCheck.Functions/Configuration/HmrcApiRateLimiterOptions.cs
@@ -12,6 +12,7 @@ namespace SFA.DAS.EmploymentCheck.Functions.Configuration
         public int TransientErrorRetryCount { get; set; } = 3;
         public int TransientErrorDelayInMs { get; set; } = 10000;
         public int TokenRetrievalRetryCount { get; set; } = 2;
+        public int TokenFailureRetryDelayInMs { get; set; } = 1000;
         public DateTime UpdateDateTime { get; set; }
     }
 }

--- a/src/SFA.DAS.EmploymentCheck.TokenServiceStub/Services/OAuthTokenService.cs
+++ b/src/SFA.DAS.EmploymentCheck.TokenServiceStub/Services/OAuthTokenService.cs
@@ -15,6 +15,8 @@ namespace SFA.DAS.EmploymentCheck.TokenServiceStub.Services
         {
             _httpClient = httpClient;
             _configuration = configuration.Value;
+
+            _httpClient.AcceptHeaders.Add(new System.Net.Http.Headers.MediaTypeWithQualityHeaderValue("application/vnd.hmrc.1.0+json"));
         }
 
         public async Task<OAuthAccessToken> GetAccessToken(string clientSecret)
@@ -26,14 +28,13 @@ namespace SFA.DAS.EmploymentCheck.TokenServiceStub.Services
                 GrantType = "client_credentials",
                 Scopes = "read:apprenticeship-levy"
             };
-
             var hmrcToken = await _httpClient.Post<OAuthTokenResponse>(_configuration.TokenUrl, request);
 
             return new OAuthAccessToken
             {
                 AccessToken = hmrcToken.AccessToken,
                 RefreshToken = hmrcToken.RefreshToken,
-                ExpiresAt = DateTime.Now.AddSeconds(hmrcToken.ExpiresIn),
+                ExpiresAt = DateTime.UtcNow.AddSeconds(hmrcToken.ExpiresIn),
                 Scope = hmrcToken.Scope,
                 TokenType = hmrcToken.TokenType
             };

--- a/src/SFA.DAS.EmploymentCheck.TokenServiceStub/Services/OAuthTokenService.cs
+++ b/src/SFA.DAS.EmploymentCheck.TokenServiceStub/Services/OAuthTokenService.cs
@@ -15,8 +15,6 @@ namespace SFA.DAS.EmploymentCheck.TokenServiceStub.Services
         {
             _httpClient = httpClient;
             _configuration = configuration.Value;
-
-            _httpClient.AcceptHeaders.Add(new System.Net.Http.Headers.MediaTypeWithQualityHeaderValue("application/vnd.hmrc.1.0+json"));
         }
 
         public async Task<OAuthAccessToken> GetAccessToken(string clientSecret)
@@ -28,13 +26,14 @@ namespace SFA.DAS.EmploymentCheck.TokenServiceStub.Services
                 GrantType = "client_credentials",
                 Scopes = "read:apprenticeship-levy"
             };
+
             var hmrcToken = await _httpClient.Post<OAuthTokenResponse>(_configuration.TokenUrl, request);
 
             return new OAuthAccessToken
             {
                 AccessToken = hmrcToken.AccessToken,
                 RefreshToken = hmrcToken.RefreshToken,
-                ExpiresAt = DateTime.UtcNow.AddSeconds(hmrcToken.ExpiresIn),
+                ExpiresAt = DateTime.Now.AddSeconds(hmrcToken.ExpiresIn),
                 Scope = hmrcToken.Scope,
                 TokenType = hmrcToken.TokenType
             };


### PR DESCRIPTION
- remove caching from hmrc auth token service stub
- use UTC datetime for checking token expiry as per the source
- improve logging in Hmrc Service retry code
- add a delay before refreshing token on failure while retrieving the token